### PR TITLE
Misc fixes

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -1,5 +1,5 @@
 local S = emote.S
-local facedir_to_look_horizontal = emote.facedir_to_look_horizontal
+local facedir_to_look_horizontal = emote.util.facedir_to_look_horizontal
 local vector_rotate_xz = emote.util.vector_rotate_xz
 
 emote.emotes = {}

--- a/api.lua
+++ b/api.lua
@@ -13,16 +13,16 @@ function emote.register_emote(name, def)
     emote.emotes[name] = def
 
 	minetest.register_chatcommand(name, {
-		description = S(("Makes your character perform the %s emote"):format(name)),
+		description = S("Makes your character perform the @1 emote", name),
 		func = function(playername)
 			local player = minetest.get_player_by_name(playername)
 			if emote.start(player, name) then
 				if not emote.settings.announce_in_chat then
-					return true, S(("you %s"):format(name))
+					return true, S("You @1", name)
 				end
 			else
 				if not emote.settings.announce_in_chat then
-					return false, S(("you fail to %s"):format(name))
+					return false, S("You failed to @1", name)
 				end
 			end
 		end,
@@ -111,7 +111,7 @@ function emote.attach_to_node(player, pos, locked)
 		local object = minetest.add_entity(new_pos, "emote:attacher")
 		if object then
 			object:get_luaentity():init(player)
-			object:setyaw(rotation)
+			object:set_yaw(rotation)
 
 			player:set_attach(object, "", emotedef.eye_offset, minetest.facedir_to_dir(node.param2))
 
@@ -121,7 +121,7 @@ function emote.attach_to_node(player, pos, locked)
 	else
 		emote.set_animation(player, emotedef.emotestring)
 
-		player:setpos(new_pos)
+		player:set_pos(new_pos)
 		player:set_eye_offset(emotedef.eye_offset, {x = 0, y = 0, z = 0})
 	end
 

--- a/api.lua
+++ b/api.lua
@@ -105,7 +105,7 @@ function emote.attach_to_node(player, pos, locked)
 	local rotation = look_horizontal + emotedef.look_horizontal_offset
 	local new_pos = vector.add(pos, offset)
 
-	emote.set_animation(player, emotedef.emotestring)
+	emote.start(player, emotedef.emotestring)
 
 	if locked then
 		local object = minetest.add_entity(new_pos, "emote:attacher")
@@ -119,8 +119,6 @@ function emote.attach_to_node(player, pos, locked)
 		end
 
 	else
-		emote.set_animation(player, emotedef.emotestring)
-
 		player:set_pos(new_pos)
 		player:set_eye_offset(emotedef.eye_offset, {x = 0, y = 0, z = 0})
 	end

--- a/init.lua
+++ b/init.lua
@@ -34,21 +34,18 @@ emote.register_emote("sit", {
 	anim_name = "sit",
 	speed = 30,
 	description = S("sits"),
-	eye_offset = vector.new(0, -5, 0)
 })
 
 emote.register_emote("lay", {
 	anim_name = "lay",
 	speed = 30,
 	description = S("lies down"),
-	eye_offset = vector.new(0, -10, -5)
 })
 
 emote.register_emote("sleep", { -- alias for lay
 	anim_name = "lay",
 	speed = 30,
 	description = S("falls asleep"),
-	eye_offset = vector.new(0, -10, -5)
 })
 
 model.animations.wave = {x = 192, y = 196, override_local = true}


### PR DESCRIPTION
* `eye_offset` is ~not~ redundant, I don't know why but setting the offset ruins the offset instead
* Translations are now using `@1` syntax instead of `%s`.
* Replaced some deprecated calls.
* Fixed reference to `emote.util.facedir_to_look_horizontal`.